### PR TITLE
[Fix] CI 테스트 실패 버그 수정

### DIFF
--- a/tests/test_05_backend_main.py
+++ b/tests/test_05_backend_main.py
@@ -23,9 +23,6 @@ def test_chat_endpoint():
 
 def test_chat_endpoint_with_agent():
     """/chat 엔드포인트가 에이전트와 연동하여 정상적으로 응답하는지 테스트합니다."""
-    # 의도적인 버그 삽입
-    assert 1 == 2, "의도적으로 실패하는 테스트 버그"
-
     # ChatRequest 모델에 맞는 형식으로 요청 데이터를 수정합니다.
     request_data = {
         "messages": [


### PR DESCRIPTION
의도적으로 발생시켰던 CI 테스트 실패 버그를 수정합니다.

- `tests/test_05_backend_main.py` 파일의 `assert 1 == 2` 구문을 제거했습니다.

Closes #2